### PR TITLE
Add file and folder icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ use {
         require("dired").setup {
             path_separator = "/",
             show_banner = false,
+            show_icons = false,
             show_hidden = true,
             show_dot_dirs = true,
             show_colors = true,
@@ -41,8 +42,9 @@ You can require this plugin and use it like this.
 
 -- Set up the 'dired' plugin with custom options
 require("dired").setup({
-    path_separator = "/",               -- Use '/' as the path separator
-    show_hidden = true,                 -- Show hidden files
+    path_separator = "/",                -- Use '/' as the path separator
+    show_hidden = true,                  -- Show hidden files
+    show_icons = false,                  -- Show icons (patched font required)
     show_banner = false,                 -- Do not show the banner
     hide_details = false,                -- Show file details by default
     sort_order = "name",                 -- Sort files by name by default

--- a/lua/dired/colors.lua
+++ b/lua/dired/colors.lua
@@ -96,23 +96,43 @@ function M.get_component_str(component)
             line = string.format("%s", component.filename),
         }
     end
-    return {
-        component = component,
-        line = string.format(
-            "%s %s %s %s %s %s %s %s %s",
-            -- component.permissions,
-            hl.get_highlighted_string(component.permissions, M.get_permission_color()),
-            component.nlinks,
-            component.owner,
-            component.group,
-            component.size,
-            component.month,
-            component.day,
-            component.ftime,
-            component.ficon,
-            component.filename
-        ),
-    }
+
+    if vim.g.dired_show_icons == true then
+        return {
+            component = component,
+            line = string.format(
+                "%s %s %s %s %s %s %s %s %s",
+                -- component.permissions,
+                hl.get_highlighted_string(component.permissions, M.get_permission_color()),
+                component.nlinks,
+                component.owner,
+                component.group,
+                component.size,
+                component.month,
+                component.day,
+                component.ftime,
+                component.ficon,
+                component.filename
+            ),
+        }
+    else
+        return {
+            component = component,
+            line = string.format(
+                "%s %s %s %s %s %s %s %s %s",
+                -- component.permissions,
+                hl.get_highlighted_string(component.permissions, M.get_permission_color()),
+                component.nlinks,
+                component.owner,
+                component.group,
+                component.size,
+                component.month,
+                component.day,
+                component.ftime,
+                component.filename
+            ),
+        }
+    end
 end
 
 function M.get_colored_component_str(component)
@@ -133,18 +153,32 @@ function M.get_colored_component_str(component)
             nt(component.filename, fcolor_p),
         }
     else
-        text_group = {
-            nt(component.permissions, permcolor),
-            nt(component.nlinks, nlinkcolor),
-            nt(component.owner, ownercolor),
-            nt(component.group, groupcolor),
-            nt(component.size, sizecolor),
-            nt(component.month, monthcolor),
-            nt(component.day, daycolor),
-            nt(component.ftime, ftimecolor),
-            nt(component.ficon, ftimecolor),
-            nt(component.filename, fcolor_p),
-        }
+        if vim.g.dired_show_icons == true then
+            text_group = {
+                nt(component.permissions, permcolor),
+                nt(component.nlinks, nlinkcolor),
+                nt(component.owner, ownercolor),
+                nt(component.group, groupcolor),
+                nt(component.size, sizecolor),
+                nt(component.month, monthcolor),
+                nt(component.day, daycolor),
+                nt(component.ftime, ftimecolor),
+                nt(component.ficon, ftimecolor),
+                nt(component.filename, fcolor_p),
+            }
+        else
+            text_group = {
+                nt(component.permissions, permcolor),
+                nt(component.nlinks, nlinkcolor),
+                nt(component.owner, ownercolor),
+                nt(component.group, groupcolor),
+                nt(component.size, sizecolor),
+                nt(component.month, monthcolor),
+                nt(component.day, daycolor),
+                nt(component.ftime, ftimecolor),
+                nt(component.filename, fcolor_p),
+            }
+        end
     end
 
     if component.fs_t.filetype == "link" then

--- a/lua/dired/colors.lua
+++ b/lua/dired/colors.lua
@@ -109,7 +109,7 @@ function M.get_component_str(component)
             component.month,
             component.day,
             component.ftime,
-            -- component.ficon,
+            component.ficon,
             component.filename
         ),
     }
@@ -142,7 +142,7 @@ function M.get_colored_component_str(component)
             nt(component.month, monthcolor),
             nt(component.day, daycolor),
             nt(component.ftime, ftimecolor),
-            -- nt(component.ficon, ftimecolor),
+            nt(component.ficon, ftimecolor),
             nt(component.filename, fcolor_p),
         }
     end

--- a/lua/dired/config.lua
+++ b/lua/dired/config.lua
@@ -28,6 +28,14 @@ local CONFIG_SPEC = {
             end
         end,
     },
+    show_icons = {
+        default = false,
+        check = function(val)
+            if type(val) ~= "boolean" then
+                return "Must be boolean, instead received " .. type(val)
+            end
+        end,
+    },
     hide_details = {
         default = false,
         check = function(val)

--- a/lua/dired/display.lua
+++ b/lua/dired/display.lua
@@ -159,7 +159,14 @@ function M.get_filename_from_listing(line)
     for i = idx, #splitted do
         table.insert(filename, splitted[i])
     end
-    return table.concat(filename, " ")
+
+    -- Detect if there is an icon in the "extracted" filename table.
+    if utils.tableLength(filename) > 1 then
+        -- Allways get the last bit of the table. The actual filename.
+        return filename[utils.tableLength(filename)]
+    else
+        return table.concat(filename, " ")
+    end
 end
 
 return M

--- a/lua/dired/init.lua
+++ b/lua/dired/init.lua
@@ -59,6 +59,14 @@ function M.setup(opts)
         vim.g.dired_show_hidden = config.get("show_hidden")
     end
 
+    -- global variable for show_icons
+    if config.get("show_icons") == nil then
+        -- default for show_icons is false
+        vim.g.dired_show_icons = false
+    else
+        vim.g.dired_show_icons = config.get("show_icons")
+    end
+
     -- global variable for hide_details
     if config.get("hide_details") == nil then
         -- default for show-hidden is true

--- a/lua/dired/utils.lua
+++ b/lua/dired/utils.lua
@@ -261,4 +261,10 @@ function M.get_icon_by_filetype(filetype)
     end
 end
 
+function M.tableLength(table)
+    local count = 0
+    for _ in pairs(table) do count = count + 1 end
+    return count
+end
+
 return M

--- a/lua/dired/utils.lua
+++ b/lua/dired/utils.lua
@@ -253,11 +253,11 @@ end
 
 function M.get_icon_by_filetype(filetype)
     if filetype == "directory" then
-        return "📁"
+        return " "
     elseif filetype == "link" then
-        return "➡️"
+        return "⮕ "
     elseif filetype == "file" then
-        return "📃"
+        return " "
     end
 end
 


### PR DESCRIPTION
Add file and folder icon support. 
- There is a re-work of icons support.
- There is a variable to control the appearance of icons.
- There is an update in the `README.md`.

To use the feature you need a patched font. 
The agenda for the future is:
- Add the most popular file icons for different file types with patched font.
- Try to integrate [nvim-web-devicons](https://github.com/nvim-tree/nvim-web-devicons).

I'm not sure when I'll do the future PR's though.
