### PR TITLE
Handle File Names With Spaces in Them

### DIFF
--- a/lua/dired/display.lua
+++ b/lua/dired/display.lua
@@ -166,13 +166,13 @@ function M.get_filename_from_listing(line)
         table.insert(filename, splitted[i])
     end
 
-    -- Detect if there is an icon in the "extracted" filename table.
-    if utils.tableLength(filename) > 1 then
-        -- Allways get the last bit of the table. The actual filename.
-        return filename[utils.tableLength(filename)]
-    else
-        return table.concat(filename, " ")
+    -- Detect if icons have been enabled is an icon in the "extracted" filename table.
+    -- BUG: the old implementation didn't take into account filenames with spaces
+    if vim.g.dired_show_icons == true then
+        table.remove(filename, 1)
     end
+    return table.concat(filename, " ")
 end
+
 
 return M

--- a/lua/dired/functions.lua
+++ b/lua/dired/functions.lua
@@ -1,7 +1,6 @@
 local fs = require("dired.fs")
 local config = require("dired.config")
 local display = require("dired.display")
-local utils = require("dired.utils")
 
 local M = {}
 


### PR DESCRIPTION
This pull request fixes a problem I encountered while trying to rename/open/delete a file with spaces in its name, the current implementation of the `get_filename_from_listing` function does not take into account filenames with spaces in them, this PR aims to fix that.