### PR TITLE
feat(colors): derive highlights from current colorscheme (#23)

### DIFF
--- a/doc/dired.txt
+++ b/doc/dired.txt
@@ -74,12 +74,12 @@ You can require this plugin and use it like this.
             dired_quit = "q",
         },
     
-        -- Define colors for different file types and attributes
+        -- Define colors by linking to your current colorscheme's highlight groups
+        -- bg/fg/gui are optional and only used if links are not found
         colors = {
-            DiredDimText = { link = {}, bg = "NONE", fg = "505050", gui = "NONE" },
-            DiredDirectoryName = { link = {}, bg = "NONE", fg = "9370DB", gui = "NONE" },
-            -- ... (define more colors as needed)
-            DiredMoveFile = { link = {}, bg = "NONE", fg = "ff3399", gui = "bold" },
+            DiredDirectoryName = { link = { "Directory", "Title" } },
+            DiredFileName = { link = { "Normal" } },
+            -- ... (override any groups you want)
         },
     })
 <
@@ -264,31 +264,31 @@ any order):
   altfont         
   nocombine       override attributes instead of combining them
   NONE            no attributes used (used to reset it)
-The default color configuration is given below
+The default color configuration links to your current colorscheme's groups:
 
 >lua
     {
-        DiredDimText = { link = {}, bg = "NONE", fg = "505050", gui = "NONE" },
-        DiredDirectoryName = { link = {}, bg = "NONE", fg = "9370DB", gui = "NONE" },
-        DiredDotfile = { link = {}, bg = "NONE", fg = "626262" },
-        DiredFadeText1 = { link = {}, bg = "NONE", fg = "626262", gui = "NONE" },
-        DiredFadeText2 = { link = {}, bg = "NONE", fg = "444444", gui = "NONE" },
-        DiredSize = { link = { "Normal" }, bg = "NONE", fg = "None", gui = "NONE" },
-        DiredUsername = { link = {}, bg = "NONE", fg = "87CEFA", gui = "bold" },
-        DiredMonth = { link = { "Normal" }, bg = "NONE", fg = "None", gui = "bold" },
-        DiredDay = { link = { "Normal" }, bg = "NONE", fg = "None", gui = "bold" },
-        DiredFileName = { link = {}, bg = "NONE", fg = "NONE", gui = "NONE" },
-        DiredFileSuid = { link = {}, bg = "ff6666", fg = "000000", gui = "bold" },
-        DiredNormal = { link = { "Normal" }, bg = "NONE", fg = "NONE", gui = "NONE" },
-        DiredNormalBold = { link = {}, bg = "NONE", fg = "ffffff", gui = "bold" },
-        DiredSymbolicLink = { link = {}, bg = "NONE", fg = "33ccff", gui = "bold" },
-        DiredBrokenLink = { link = {}, bg = "2e2e1f", fg = "ff1a1a", gui = "bold" },
-        DiredSymbolicLinkTarget = { link = {}, bg = "5bd75b", fg = "000000", gui = "bold" },
-        DiredBrokenLinkTarget = { link = {}, bg = "2e2e1f", fg = "ff1a1a", gui = "bold" },
-        DiredFileExecutable = { link = {}, bg = "NONE", fg = "5bd75b", gui = "bold" },
-        DiredMarkedFile = { link = {}, bg = "NONE", fg = "a8b103", gui = "bold" },
-        DiredCopyFile = { link = {}, bg = "NONE", fg = "ff8533", gui = "bold" },
-        DiredMoveFile = { link = {}, bg = "NONE", fg = "ff3399", gui = "bold" },
+        DiredDimText = { link = { "Comment" } },
+        DiredDirectoryName = { link = { "Directory", "Title" } },
+        DiredDotfile = { link = { "Comment", "NonText" } },
+        DiredFadeText1 = { link = { "Comment" } },
+        DiredFadeText2 = { link = { "NonText", "Comment" } },
+        DiredSize = { link = { "Number", "Normal" } },
+        DiredUsername = { link = { "Identifier", "Title" } },
+        DiredMonth = { link = { "Normal", "Title" } },
+        DiredDay = { link = { "Normal", "Title" } },
+        DiredFileName = { link = { "Normal" } },
+        DiredFileSuid = { link = { "Error", "ErrorMsg", "WarningMsg" } },
+        DiredNormal = { link = { "Normal" } },
+        DiredNormalBold = { link = { "Normal" } },
+        DiredSymbolicLink = { link = { "Special", "Type", "Identifier" } },
+        DiredBrokenLink = { link = { "Error", "ErrorMsg" } },
+        DiredSymbolicLinkTarget = { link = { "String", "Special" } },
+        DiredBrokenLinkTarget = { link = { "WarningMsg", "ErrorMsg" } },
+        DiredFileExecutable = { link = { "Function", "Statement", "Type" } },
+        DiredMarkedFile = { link = { "Visual", "Search" } },
+        DiredCopyFile = { link = { "DiffChange", "Type" } },
+        DiredMoveFile = { link = { "DiffDelete", "WarningMsg" } },
     }
 <
 

--- a/lua/dired/config.lua
+++ b/lua/dired/config.lua
@@ -113,32 +113,42 @@ local CONFIG_SPEC = {
     },
     colors = {
         default = {
-            DiredDimText = { link = {}, bg = "NONE", fg = "505050", gui = "NONE" },
-            DiredDirectoryName = { link = {}, bg = "NONE", fg = "9370DB", gui = "NONE" },
-            DiredDotfile = { link = {}, bg = "NONE", fg = "626262" },
-            DiredFadeText1 = { link = {}, bg = "NONE", fg = "626262", gui = "NONE" },
-            DiredFadeText2 = { link = {}, bg = "NONE", fg = "444444", gui = "NONE" },
-            DiredSize = { link = { "Normal" }, bg = "NONE", fg = "None", gui = "NONE" },
-            DiredUsername = { link = {}, bg = "NONE", fg = "87CEFA", gui = "bold" },
-            DiredMonth = { link = { "Normal" }, bg = "NONE", fg = "None", gui = "bold" },
-            DiredDay = { link = { "Normal" }, bg = "NONE", fg = "None", gui = "bold" },
-            DiredFileName = { link = {}, bg = "NONE", fg = "NONE", gui = "NONE" },
-            DiredFileSuid = { link = {}, bg = "ff6666", fg = "000000", gui = "bold" },
-            DiredNormal = { link = { "Normal" }, bg = "NONE", fg = "NONE", gui = "NONE" },
-            DiredNormalBold = { link = {}, bg = "NONE", fg = "ffffff", gui = "bold" },
-            DiredSymbolicLink = { link = {}, bg = "NONE", fg = "33ccff", gui = "bold" },
-            DiredBrokenLink = { link = {}, bg = "2e2e1f", fg = "ff1a1a", gui = "bold" },
-            DiredSymbolicLinkTarget = { link = {}, bg = "5bd75b", fg = "000000", gui = "bold" },
-            DiredBrokenLinkTarget = { link = {}, bg = "2e2e1f", fg = "ff1a1a", gui = "bold" },
-            DiredFileExecutable = { link = {}, bg = "NONE", fg = "5bd75b", gui = "bold" },
-            DiredMarkedFile = { link = {}, bg = "NONE", fg = "a8b103", gui = "bold" },
-            DiredCopyFile = { link = {}, bg = "NONE", fg = "ff8533", gui = "bold" },
-            DiredMoveFile = { link = {}, bg = "NONE", fg = "ff3399", gui = "bold" },
+            -- Use current theme groups via links; fg/bg/gui are optional and omitted
+            DiredDimText = { link = { "Comment" } },
+            DiredDirectoryName = { link = { "Directory", "Title" } },
+            DiredDotfile = { link = { "Comment", "NonText" } },
+            DiredFadeText1 = { link = { "Comment" } },
+            DiredFadeText2 = { link = { "NonText", "Comment" } },
+            DiredSize = { link = { "Number", "Normal" } },
+            DiredUsername = { link = { "Identifier", "Title" } },
+            DiredMonth = { link = { "Normal", "Title" } },
+            DiredDay = { link = { "Normal", "Title" } },
+            DiredFileName = { link = { "Normal" } },
+            DiredFileSuid = { link = { "Error", "ErrorMsg", "WarningMsg" } },
+            DiredNormal = { link = { "Normal" } },
+            DiredNormalBold = { link = { "Normal" } },
+            DiredSymbolicLink = { link = { "Special", "Type", "Identifier" } },
+            DiredBrokenLink = { link = { "Error", "ErrorMsg" } },
+            DiredSymbolicLinkTarget = { link = { "String", "Special" } },
+            DiredBrokenLinkTarget = { link = { "WarningMsg", "ErrorMsg" } },
+            DiredFileExecutable = { link = { "Function", "Statement", "Type" } },
+            DiredMarkedFile = { link = { "Visual", "Search" } },
+            DiredCopyFile = { link = { "DiffChange", "Type" } },
+            DiredMoveFile = { link = { "DiffDelete", "WarningMsg" } },
         },
         check = function(cfg)
             for k, v in pairs(cfg) do
-                if v["link"] == nil or v["bg"] == nil or v["fg"] == nil or v["gui"] == nil then
-                    return "Must contain a link, bg, fg and gui element for each highlight group"
+                if v["link"] == nil then
+                    return "Must contain a link element for each highlight group"
+                end
+                if type(v["link"]) ~= "table" then
+                    return "link must be a table of highlight groups for " .. tostring(k)
+                end
+                -- bg/fg/gui are optional; if provided, must be strings
+                for _, key in ipairs({ "bg", "fg", "gui" }) do
+                    if v[key] ~= nil and type(v[key]) ~= "string" then
+                        return key .. " must be a string when provided for " .. tostring(k)
+                    end
                 end
             end
         end,

--- a/lua/dired/highlight.lua
+++ b/lua/dired/highlight.lua
@@ -278,17 +278,17 @@ M.setup = function()
         )
         create_highlight_group(
             M.SYMBOLIC_LINK_TARGET,
-            clr.DiredBrokenLink.link,
-            clr.DiredBrokenLink.bg,
-            clr.DiredBrokenLink.fg,
-            clr.DiredBrokenLink.gui
-        )
-        create_highlight_group(
-            M.BROKEN_LINK,
             clr.DiredSymbolicLinkTarget.link,
             clr.DiredSymbolicLinkTarget.bg,
             clr.DiredSymbolicLinkTarget.fg,
             clr.DiredSymbolicLinkTarget.gui
+        )
+        create_highlight_group(
+            M.BROKEN_LINK,
+            clr.DiredBrokenLink.link,
+            clr.DiredBrokenLink.bg,
+            clr.DiredBrokenLink.fg,
+            clr.DiredBrokenLink.gui
         )
         create_highlight_group(
             M.BROKEN_LINK_TARGET,


### PR DESCRIPTION
### Issue: Colors do not respect current colorscheme (#23)

- **Problem**: Dired used fixed hex colors; didn’t adapt to active colorscheme. Some symlink highlight mappings were also incorrect.
- **Impact**: Inconsistent visuals across themes; poor contrast in some colorschemes.

### Steps to Reproduce (before)
1. Load any colorscheme with non-default palette.
2. Open Dired (`:Dired`).
3. Observe fixed colors that don’t match the theme, and incorrect symlink target/broken coloring.

### Expected
- Highlights should link to the current colorscheme’s groups.
- Symlink and broken symlink groups should be mapped correctly.

### Actual (before)
- Hardcoded fg/bg values override theme.
- `DiredSymbolicLinkTarget`/`DiredBrokenLink` mappings were swapped.

### Fix Summary
- Default colors now link to theme highlight groups; fg/bg/gui are optional fallbacks.
- Corrected symlink target vs broken link mappings.
- Updated docs to reflect theme-linked defaults.

### Configuration Example
```lua
require(dired).setup({
  colors = {
    -- Uses your colorscheme’s groups; fg/bg/gui optional
    DiredDirectoryName = { link = { Directory, Title } },
    DiredFileName = { link = { Normal } },
  },
})
```

### Verification
- Switch between light/dark colorschemes.
- Open Dired; confirm colors adapt and symlink/broken targets are highlighted appropriately.

### Notes
- Users can still override any group via `colors` config.