### PR TITLE
Fix: Dir Sorting

### DIFF
--- a/lua/dired/sort.lua
+++ b/lua/dired/sort.lua
@@ -1,5 +1,3 @@
--- TODO: Implement these
-
 local M = {}
 function M.sort_by_name(left, right)
     left = left.component.fs_t
@@ -13,7 +11,6 @@ function M.sort_by_date(left, right)
     return left.stat.mtime.sec < right.stat.mtime.sec
 end
 
--- TODO: Implement these
 function M.sort_by_dirs(left, right)
     left = left.component.fs_t
     right = right.component.fs_t

--- a/lua/dired/sort.lua
+++ b/lua/dired/sort.lua
@@ -17,11 +17,16 @@ end
 function M.sort_by_dirs(left, right)
     left = left.component.fs_t
     right = right.component.fs_t
-    if left.filetype ~= right.filetype then
-        return left.filetype < right.filetype
-    else
-        return left.filename:lower() < right.filename:lower()
+    -- Ensure directories are always listed before non-directories
+    local left_is_dir = left.filetype == "directory"
+    local right_is_dir = right.filetype == "directory"
+
+    if left_is_dir ~= right_is_dir then
+        return left_is_dir and not right_is_dir
     end
+
+    -- If both are directories or both are non-directories, sort by name
+    return left.filename:lower() < right.filename:lower()
 end
 
 return M


### PR DESCRIPTION
### PR Title
fix(sort): ensure directories are listed before files in dirs sort

### PR Description
- Fix the "dirs" sort comparator to always place entries with `filetype == "directory"` before non-directories.
- Previously the comparator compared `filetype` strings lexicographically, causing some files to appear above `"directory"`.

### Technical Details
- Update `lua/dired/sort.lua`:
  - Add explicit directory-first logic in `sort_by_dirs`.
  - Fall back to case-insensitive name sort when both are directories or both are non-directories.

### Rationale
- Sorting by “dirs” should prioritize directories consistently.
- Fixes cases where files like `kitty.conf` appeared before `"."` and `".."`.

### How to Test
- Open a directory with mixed files and subdirectories.
- Set `vim.g.dired_sort_order = "dirs"`.
- Verify directories (including `"."` and `".."` when shown) appear before files.

### Screenshots
- Before:
<img width="1181" height="303" alt="Screenshot from 2025-09-24 13-37-33" src="https://github.com/user-attachments/assets/2867a808-7b91-4a19-b347-ab79e0ca72e8" />

  - 
- After:
<img width="1181" height="303" alt="Screenshot from 2025-09-24 13-34-53" src="https://github.com/user-attachments/assets/d437f828-c3f5-4db1-ae0b-53eed5b76fa2" />


### Files Changed
- `lua/dired/sort.lua`