### PR TITLE
feat(config): add `override_cwd` option to control cwd behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ require("dired").setup({
     show_banner = false,                 -- Do not show the banner
     hide_details = false,                -- Show file details by default
     sort_order = "name",                 -- Sort files by name by default
+    override_cwd = true,                 -- Override cwd by default
 
     -- Define keybindings for various 'dired' actions
     keybinds = {

--- a/doc/dired.txt
+++ b/doc/dired.txt
@@ -64,6 +64,7 @@ You can require this plugin and use it like this.
         hide_details = false,                -- Show file details by default
         sort_order = "name",                 -- Sort files by name by default
     
+        override_cwd = true,                 -- Override cwd by default
         -- Define keybindings for various 'dired' actions
         keybinds = {
             dired_enter = "<CR>",

--- a/lua/dired/config.lua
+++ b/lua/dired/config.lua
@@ -44,6 +44,14 @@ local CONFIG_SPEC = {
             end
         end,
     },
+    override_cwd = {
+        default = true,
+        check = function (val)
+            if type(val) ~= "boolean" then
+                return "Must be boolean, instead received " .. type(val)
+            end
+        end
+    },
     -- control mouse/preview UX
     enable_click_preview = {
         -- highlights the current line on single left-click

--- a/lua/dired/dired.lua
+++ b/lua/dired/dired.lua
@@ -44,14 +44,22 @@ function M.init_dired()
     if fs.is_directory(path) ~= true then
         path = fs.get_parent_path(path)
     end
-    vim.api.nvim_set_current_dir(path)
+
+    if vim.g.dired_override_cwd then
+        vim.api.nvim_set_current_dir(path)
+    end
+
     display.render(path)
 end
 
 -- open a new directory
 function M.open_dir(path)
     if path == "" then
-        path = "."
+        if vim.g.dired_override_cwd then
+            path = "."
+        else
+            path = vim.fn.fnamemodify(vim.fn.expand("%"), ":p"):gsub("\\", "/")
+        end
     end
 
     path = fs.get_simplified_path(fs.get_absolute_path(path))

--- a/lua/dired/init.lua
+++ b/lua/dired/init.lua
@@ -95,6 +95,13 @@ function M.setup(opts)
         vim.g.dired_sort_order = config.get("sort_order")
     end
 
+    if config.get("override_cwd") == nil then
+        -- Default: true (do override user's cwd)
+        vim.g.dired_override_cwd = true
+    else
+        vim.g.dired_override_cwd = config.get("override_cwd")
+    end
+
     vim.cmd([[command! -nargs=? -complete=dir Dired lua require'dired'.open(<q-args>)]])
     vim.cmd([[command! -nargs=? -complete=file DiredRename lua require'dired'.rename(<q-args>)]])
     vim.cmd([[command! -nargs=? -complete=file DiredDelete lua require'dired'.delete(<q-args>)]])


### PR DESCRIPTION
I really like this plugin, but having it automatically override the current working directory has been inconvenient, as it affects other plugins and settings that rely on `vim.fn.getcwd()`, such as LSPs and fuzzy finders.

This PR adds a new configuration option: `override_cwd`. By default, it is set to `true` to preserve the existing behavior of changing working directory when opening dired.nvim. Setting it to `false` prevents dired from overriding the user’s cwd and instead uses the directory relative to the currently opened file, similar to `netrw`.