### PR TITLE
replace lone single-quote (') with space in get_icon_by_filetype()

### DIFF
--- a/lua/dired/filetype.lua
+++ b/lua/dired/filetype.lua
@@ -482,7 +482,7 @@ function M.get_icon_by_filetype(filetype)
     elseif filetype == "tsx" then
         return " "
     elseif filetype == "nix" then
-        return "'"
+        return " "
     elseif filetype == "shell" then
         return " "
     elseif filetype == "zsh" then


### PR DESCRIPTION
The get_icon_by_filetype() function returns the nix icon appended by a single-quote ('), rather than a space. This causes dired to fail to open *.nix files due to an off-by-one error arising from how filenames are parsed.

Every other option returns the icon followed by a space. This commit corrects the discrepancy by replacing the single-quote with a space.

Fixes #42